### PR TITLE
Add progress dialogs

### DIFF
--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -6,6 +6,7 @@ using namespace cli;
 
 #include <QMessageBox>
 #include <QTemporaryDir>
+#include <QProgressDialog>
 
 #include <imodinterface.h>
 #include <iplugingame.h>
@@ -164,9 +165,11 @@ OMODFrameworkWrapper::EInstallResult OMODFrameworkWrapper::install(MOBase::Guess
   try
   {
     MessageBoxHelper::unique_ptr messageBoxHelper = MessageBoxHelper::make_unique();
+    auto cphDeleter = [](CodeProgressHelper* cph) { cph->deleteLater(); };
+    std::unique_ptr<CodeProgressHelper, decltype(cphDeleter)> codeProgressHelper(new CodeProgressHelper(mParentWidget), cphDeleter);
 
     QTemporaryDir tempPath(toQString(System::IO::Path::Combine(System::IO::Path::GetPathRoot(toDotNetString(mMoInfo->modsPath())), "OMODTempXXXXXX")));
-    initFrameworkSettings(tempPath.path());
+    initFrameworkSettings(codeProgressHelper.get(), tempPath.path());
     MOBase::log::debug("Installing {} as OMOD", archiveName);
     // Stack allocating should dispose like a `using` statement in C#
     emit showWaitDialog("Initializing OMOD installer... ");
@@ -365,9 +368,9 @@ OMODFrameworkWrapper::EInstallResult OMODFrameworkWrapper::install(MOBase::Guess
   }
 }
 
-void OMODFrameworkWrapper::initFrameworkSettings(const QString& tempPath)
+void OMODFrameworkWrapper::initFrameworkSettings(CodeProgressHelper *helper, const QString& tempPath)
 {
-  OMODFramework::Framework::Settings->CodeProgress = gcnew CodeProgress();
+  OMODFramework::Framework::Settings->CodeProgress = gcnew CodeProgress(helper);
 
   if (!tempPath.isEmpty())
     OMODFramework::Framework::Settings->TempPath = toDotNetString(tempPath);

--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -61,6 +61,7 @@ System::Reflection::Assembly^ AssemblyResolver::OnAssemblyResolve(System::Object
 OMODFrameworkWrapper::OMODFrameworkWrapper(MOBase::IOrganizer* organizer, QWidget* parentWidget)
   : mMoInfo(organizer)
   , mParentWidget(parentWidget)
+  , mWaitDialog(nullptr, &progressDialogDeleter)
 {
   AssemblyResolver::initialise(mMoInfo);
 
@@ -421,13 +422,16 @@ void OMODFrameworkWrapper::displayReadmeSlot(const QString& modName, const QStri
 }
 
 void OMODFrameworkWrapper::showWaitDialogSlot(QString message) {
-  mWaitDialog = new QProgressDialog(message, QString(), 0, 0, mParentWidget);
+  mWaitDialog = progress_unique_ptr(new QProgressDialog(message, QString(), 0, 0, mParentWidget), &progressDialogDeleter);
   mWaitDialog->setWindowFlags(mWaitDialog->windowFlags() & ~Qt::WindowContextHelpButtonHint & ~Qt::WindowCloseButtonHint);
   mWaitDialog->setWindowModality(Qt::WindowModal);
   mWaitDialog->show();
 }
 
 void OMODFrameworkWrapper::hideWaitDialogSlot() {
-  mWaitDialog->hide();
-  mWaitDialog->deleteLater();
+  if (mWaitDialog) {
+    mWaitDialog->hide();
+    mWaitDialog->deleteLater();
+    mWaitDialog = nullptr;
+  }
 }

--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -421,10 +421,9 @@ void OMODFrameworkWrapper::displayReadmeSlot(const QString& modName, const QStri
 }
 
 void OMODFrameworkWrapper::showWaitDialogSlot(QString message) {
-  mWaitDialog = new QProgressDialog(message, tr("Cancel"), 0, 0, mParentWidget);
+  mWaitDialog = new QProgressDialog(message, QString(), 0, 0, mParentWidget);
   mWaitDialog->setWindowFlags(mWaitDialog->windowFlags() & ~Qt::WindowContextHelpButtonHint & ~Qt::WindowCloseButtonHint);
   mWaitDialog->setWindowModality(Qt::WindowModal);
-  mWaitDialog->setCancelButton(nullptr);
   mWaitDialog->show();
 }
 

--- a/src/OMODFrameworkWrapper.h
+++ b/src/OMODFrameworkWrapper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QCoreApplication>
+#include <QProgressDialog>
 
 #include <iplugininstaller.h>
 
@@ -29,12 +30,18 @@ signals:
 
   void displayReadme(const QString& modName, const QString& readme);
 
+  void showWaitDialog(QString message);
+  void hideWaitDialog();
+
 protected slots:
   void createModSlot(MOBase::IModInterface*& modInterfaceOut, MOBase::GuessedValue<QString>& modName);
-
   void displayReadmeSlot(const QString& modName, const QString& readme);
+  
+  void showWaitDialogSlot(QString message);
+  void hideWaitDialogSlot();
 
 private:
   MOBase::IOrganizer* mMoInfo;
   QWidget* mParentWidget;
+  QProgressDialog* mWaitDialog;
 };

--- a/src/OMODFrameworkWrapper.h
+++ b/src/OMODFrameworkWrapper.h
@@ -5,6 +5,8 @@
 
 #include <iplugininstaller.h>
 
+#include "implementations/CodeProgress.h"
+
 // define this here as it's going to be used a lot by things using this class' message box wrappers.
 template<class T>
 T& unused_out(T&& t) { return t; }
@@ -23,7 +25,7 @@ public:
   EInstallResult install(MOBase::GuessedValue<QString>& modName, QString gameName, const QString& archiveName, const QString& version, int nexusID);
 
 protected:
-  void initFrameworkSettings(const QString& tempPath);
+  void initFrameworkSettings(CodeProgressHelper* helper, const QString& tempPath);
 
 signals:
   void createMod(MOBase::IModInterface*& modInterfaceOut, MOBase::GuessedValue<QString>& modName);

--- a/src/OMODFrameworkWrapper.h
+++ b/src/OMODFrameworkWrapper.h
@@ -45,5 +45,8 @@ protected slots:
 private:
   MOBase::IOrganizer* mMoInfo;
   QWidget* mParentWidget;
-  QProgressDialog* mWaitDialog;
+
+  static void progressDialogDeleter(QProgressDialog* obj) { obj->deleteLater(); }
+  using progress_unique_ptr = std::unique_ptr<QProgressDialog, decltype(progressDialogDeleter)*>;
+  progress_unique_ptr mWaitDialog;
 };

--- a/src/implementations/CodeProgress.cpp
+++ b/src/implementations/CodeProgress.cpp
@@ -1,11 +1,70 @@
+#include <QApplication>
+
 #include "CodeProgress.h"
 
 #include <log.h>
+
+CodeProgressHelper::CodeProgressHelper(QWidget* parentWidget) : mParentWidget{ parentWidget }, mProgressDialog{ nullptr } {
+  moveToThread(QApplication::instance()->thread());
+  connect(this, &CodeProgressHelper::ShowProgressDialogSignal, this, &CodeProgressHelper::ShowProgressDialogSlot, Qt::QueuedConnection);
+  connect(this, &CodeProgressHelper::UpdateProgressValueSignal, this, &CodeProgressHelper::UpdateProgressValueSlot, Qt::QueuedConnection);
+  connect(this, &CodeProgressHelper::HideProgressDialogSignal, this, &CodeProgressHelper::HideProgressDialogSlot, Qt::QueuedConnection);
+
+}
+CodeProgressHelper::~CodeProgressHelper() {
+  if (mProgressDialog) {
+    mProgressDialog->deleteLater();
+  }
+}
+
+void CodeProgressHelper::ShowProgressDialog(__int64 totalSize) {
+  emit ShowProgressDialogSignal(totalSize);
+}
+
+void CodeProgressHelper::UpdateProgressValue(__int64 size) {
+  emit UpdateProgressValueSignal(size);
+}
+
+void CodeProgressHelper::HideProgressDialog() {
+  emit HideProgressDialogSignal();
+}
+
+void CodeProgressHelper::ShowProgressDialogSlot(__int64 totalSize) {
+  if (mProgressDialog) {
+    mProgressDialog->deleteLater();
+  }
+  mTotalSize = totalSize;
+
+  mProgressDialog = new QProgressDialog(mParentWidget);
+  mProgressDialog->setWindowFlags(mProgressDialog->windowFlags() & ~Qt::WindowContextHelpButtonHint & ~Qt::WindowCloseButtonHint);
+  mProgressDialog->setWindowModality(Qt::WindowModal);
+  mProgressDialog->setCancelButton(nullptr);
+  mProgressDialog->setMinimum(0);
+  mProgressDialog->setMaximum(100);
+  mProgressDialog->setAutoReset(false);
+  mProgressDialog->setAutoClose(false);
+  mProgressDialog->show();
+}
+
+void CodeProgressHelper::UpdateProgressValueSlot(__int64 size) {
+  int percent = (int)(100 * size / (double)mTotalSize);
+  if (percent != mProgressDialog->value()) {
+    mProgressDialog->setValue(percent);
+  }
+}
+
+void CodeProgressHelper::HideProgressDialogSlot() {
+  mProgressDialog->hide();
+  mProgressDialog->deleteLater();
+  mProgressDialog = nullptr;
+ }
 
 void CodeProgress::Init(__int64 totalSize, bool compressing)
 {
   mTotalSize = totalSize;
   mCompressing = compressing;
+
+  mHelper->ShowProgressDialog(totalSize);
   MOBase::log::debug("CodeProgress::Init called with {} {}", totalSize, compressing);
 
   // TODO: this
@@ -13,10 +72,12 @@ void CodeProgress::Init(__int64 totalSize, bool compressing)
 
 void CodeProgress::SetProgress(__int64 inSize, __int64 outSize)
 {
-  MOBase::log::debug("CodeProgress::SetProgress called with {} {}", inSize, outSize);
+  // MOBase::log::debug("CodeProgress::SetProgress called with {} {}", inSize, outSize);
+  mHelper->UpdateProgressValue(inSize);
 }
 
 CodeProgress::~CodeProgress()
 {
   MOBase::log::debug("CodeProgress 'destructor' called");
+  mHelper->HideProgressDialog();
 }

--- a/src/implementations/CodeProgress.h
+++ b/src/implementations/CodeProgress.h
@@ -1,10 +1,45 @@
 #pragma once
 
+#include <QObject>
+#include <QWidget>
+#include <QProgressDialog>
+
 using namespace cli;
+
+class CodeProgressHelper : public QObject {
+  Q_OBJECT
+public:
+
+  CodeProgressHelper(QWidget* parentWidget);
+  ~CodeProgressHelper();
+
+  void ShowProgressDialog(__int64 totalSize);
+  void UpdateProgressValue(__int64 size);
+  void HideProgressDialog();
+
+public slots:
+  void ShowProgressDialogSlot(__int64 totalSize);
+  void UpdateProgressValueSlot(__int64 size);
+  void HideProgressDialogSlot();
+
+signals:
+
+  void ShowProgressDialogSignal(__int64 totalSize);
+  void UpdateProgressValueSignal(__int64 size);
+  void HideProgressDialogSignal();
+
+private:
+  QWidget* mParentWidget;
+  QProgressDialog* mProgressDialog;
+  __int64 mTotalSize;
+};
 
 ref class CodeProgress : OMODFramework::ICodeProgress
 {
 public:
+
+  CodeProgress(CodeProgressHelper *helper) : mHelper(helper) { }
+
   virtual void Init(__int64 totalSize, bool compressing);
 
   virtual void SetProgress(__int64 inSize, __int64 outSize);
@@ -12,6 +47,7 @@ public:
   ~CodeProgress();
 
 private:
+  CodeProgressHelper* mHelper;
   __int64 mTotalSize;
   bool mCompressing;
 };

--- a/src/implementations/ScriptFunctions.cpp
+++ b/src/implementations/ScriptFunctions.cpp
@@ -169,7 +169,7 @@ void ScriptFunctions::DisplayText(System::String^ text, System::String^ title)
 {
   RtfPopup popup(text, mParentWidget);
   popup.setWindowTitle(toQString(title));
-  popup.exec();
+  popup.show();
 }
 
 void ScriptFunctions::Patch(System::String^ from, System::String^ to)

--- a/src/installer_omod_en.ts
+++ b/src/installer_omod_en.ts
@@ -17,59 +17,64 @@
 <context>
     <name>OMODFrameworkWrapper</name>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="402"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="407"/>
         <source>Display Readme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="404"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="409"/>
         <source>The Readme may explain installation options. Display it?&lt;br&gt;It will remain visible until you close it.</source>
         <extracomment>&lt;br&gt; is a line break. Translators can remove it if it makes things clearer.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="410"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="415"/>
         <source>%1 Readme</source>
         <extracomment>%1 is the mod name</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="231"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="236"/>
         <source>%1 wants to change [%2] %3 from &quot;%4&quot; to &quot;%5&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %4 is the value already in Oblivion.ini. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="240"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="245"/>
         <source>%1 wants to set [%2] %3 to &quot;%4&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="243"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="248"/>
         <source>Update INI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="286"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="291"/>
         <source>%1 installed and wants to activate the following plugins:&lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt;However, it didn&apos;t try to activate these plugins:&lt;ul&gt;&lt;li&gt;%3&lt;/li&gt;&lt;/ul&gt;</source>
         <extracomment>%1 is the mod name &lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt; becomes a list of ESPs and ESMs the OMOD installed and tried to activate. &lt;ul&gt;&lt;li&gt;%3&lt;/li&gt;&lt;/ul&gt; becomes a list of ESPs and ESMs the OMOD installed avoided activating. The point of this popup is to suggest which plugins the user might need to activate themselves.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="290"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="295"/>
         <source>OMOD didn&apos;t activate all plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="313"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="318"/>
         <source>%1 has data for %2, but Mod Organizer 2 doesn&apos;t know what to do with it yet. Please report this to the Mod Organizer 2 development team (ideally by sending us your interface log) as we didn&apos;t find any OMODs that actually did this, and we need to know that they exist.</source>
         <extracomment>%1 is the mod name %2 is the name of a field in the OMOD&apos;s return data Hopefully this message will never be seen by anyone, but if it is, they need to know to tell the Mod Organizer 2 dev team.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="316"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="321"/>
         <source>Mod Organizer 2 can&apos;t completely install this OMOD.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="OMODFrameworkWrapper.cpp" line="422"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/installer_omod_en.ts
+++ b/src/installer_omod_en.ts
@@ -17,63 +17,63 @@
 <context>
     <name>OMODFrameworkWrapper</name>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="407"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="409"/>
         <source>Display Readme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="409"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="411"/>
         <source>The Readme may explain installation options. Display it?&lt;br&gt;It will remain visible until you close it.</source>
         <extracomment>&lt;br&gt; is a line break. Translators can remove it if it makes things clearer.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="415"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="417"/>
         <source>%1 Readme</source>
         <extracomment>%1 is the mod name</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="236"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="238"/>
         <source>%1 wants to change [%2] %3 from &quot;%4&quot; to &quot;%5&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %4 is the value already in Oblivion.ini. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="245"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="247"/>
         <source>%1 wants to set [%2] %3 to &quot;%4&quot;</source>
         <extracomment>%1 is the mod name [%2] is the ini section name. %3 is the ini setting name. %5 is the value the mod wants to set.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="248"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="250"/>
         <source>Update INI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="291"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="293"/>
         <source>%1 installed and wants to activate the following plugins:&lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt;However, it didn&apos;t try to activate these plugins:&lt;ul&gt;&lt;li&gt;%3&lt;/li&gt;&lt;/ul&gt;</source>
         <extracomment>%1 is the mod name &lt;ul&gt;&lt;li&gt;%2&lt;/li&gt;&lt;/ul&gt; becomes a list of ESPs and ESMs the OMOD installed and tried to activate. &lt;ul&gt;&lt;li&gt;%3&lt;/li&gt;&lt;/ul&gt; becomes a list of ESPs and ESMs the OMOD installed avoided activating. The point of this popup is to suggest which plugins the user might need to activate themselves.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="295"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="297"/>
         <source>OMOD didn&apos;t activate all plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="318"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="320"/>
         <source>%1 has data for %2, but Mod Organizer 2 doesn&apos;t know what to do with it yet. Please report this to the Mod Organizer 2 development team (ideally by sending us your interface log) as we didn&apos;t find any OMODs that actually did this, and we need to know that they exist.</source>
         <extracomment>%1 is the mod name %2 is the name of a field in the OMOD&apos;s return data Hopefully this message will never be seen by anyone, but if it is, they need to know to tell the Mod Organizer 2 dev team.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="321"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="323"/>
         <source>Mod Organizer 2 can&apos;t completely install this OMOD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OMODFrameworkWrapper.cpp" line="422"/>
+        <location filename="OMODFrameworkWrapper.cpp" line="424"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/newstuff/rtfPopup.cpp
+++ b/src/newstuff/rtfPopup.cpp
@@ -8,18 +8,18 @@
 
 #include "../interop/QtDotNetConverters.h"
 
-RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QDialog(parent, f)
+RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QMainWindow(nullptr, f)
 {
   QString text = rtfText->StartsWith("{\\rtf") ? toQString(RtfPipe::Rtf::ToHtml(rtfText)) : Qt::convertFromPlainText(toQString(rtfText), Qt::WhiteSpaceNormal);
   QRegularExpression urlFinder(R"REGEX((?<!(?:href="))((?:(?:https?|ftp|file)://|www\.|ftp\.)(?:\([-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;)*\)|[-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;))*(?:\([-A-Z0-9+@#/%=~+|$?!:,.]|(?:&amp;)*\)|[A-Z0-9+@#/%=~_|$]|(?:&amp;))))REGEX", QRegularExpression::CaseInsensitiveOption | QRegularExpression::MultilineOption);
   text.replace(urlFinder, R"(<a href="\1">\1</a>)");
 
-  QLayout* layout = new QGridLayout(this);
-  setLayout(layout);
+  setAttribute(Qt::WA_DeleteOnClose);
+
   QScrollArea* scrollArea = new QScrollArea(this);
   scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  layout->addWidget(scrollArea);
+  setCentralWidget(scrollArea);
 
   QLabel* label = new QLabel(text, scrollArea);
   label->setWordWrap(true);
@@ -28,6 +28,4 @@ RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) 
   label->setTextInteractionFlags(Qt::TextBrowserInteraction);
   scrollArea->setWidget(label);
   scrollArea->setWidgetResizable(true);
-
-  setSizeGripEnabled(true);
 }

--- a/src/newstuff/rtfPopup.h
+++ b/src/newstuff/rtfPopup.h
@@ -1,8 +1,8 @@
 using namespace cli;
 
-#include <QDialog>
+#include <QMainWindow>
 
-class RtfPopup : public QDialog
+class RtfPopup : public QMainWindow
 {
   Q_OBJECT
 


### PR DESCRIPTION
- Add a "wait" dialog while the OMOD framework is initializing.
- Add a progress dialog for extraction.
- `RtfDialog` is now a `QMainWindow` so it can be shown and read during extraction, etc.

Few "problems":

1. None of the dialog of cancelable, I even disable the close button because I have no idea how to cancel the process (kill the task? throw an exception?).
2. The message popup seems to block the `QMainWindow`, probably because the dialog are application-modal instead of window-modal.
3. There are still some times during the installation process where the framework is doing thing but the user is free to do what he wants, in particular right before extraction.