### PR TITLE
Rtf popup QMainWindow

### DIFF
--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -411,11 +411,10 @@ void OMODFrameworkWrapper::displayReadmeSlot(const QString& modName, const QStri
   {
     // TODO: ideally this wouldn't be part of the same window heirarchy so that modal popups in the installer don't prevent it being moved/resized etc.
     // DarNified UI's popups are modal for the whole process, so any fancy trick needs to be *here*.
-    RtfPopup* readmePopup = new RtfPopup(toDotNetString(readme), mParentWidget);
+    RtfPopup* readmePopup = new RtfPopup(toDotNetString(readme), nullptr);
     //: %1 is the mod name
     readmePopup->setWindowTitle(tr("%1 Readme").arg(modName));
     readmePopup->show();
-    readmePopup->setAttribute(Qt::WA_DeleteOnClose);
   }
 }
 

--- a/src/OMODFrameworkWrapper.cpp
+++ b/src/OMODFrameworkWrapper.cpp
@@ -414,6 +414,7 @@ void OMODFrameworkWrapper::displayReadmeSlot(const QString& modName, const QStri
     RtfPopup* readmePopup = new RtfPopup(toDotNetString(readme), nullptr);
     //: %1 is the mod name
     readmePopup->setWindowTitle(tr("%1 Readme").arg(modName));
+    readmePopup->setAttribute(Qt::WA_DeleteOnClose);
     readmePopup->show();
   }
 }

--- a/src/implementations/ScriptFunctions.cpp
+++ b/src/implementations/ScriptFunctions.cpp
@@ -90,7 +90,11 @@ void ScriptFunctionsHelper::DisplayTextSlot(QWidget* parentWidget, const QString
   popup.setWindowTitle(title);
   // the size readmes are becoming automatically
   popup.resize(492, 366);
-  popup.exec();
+  popup.setWindowModality(Qt::ApplicationModal);
+  popup.show();
+  QEventLoop loop;
+  connect(&popup, SIGNAL(closed()), &loop, SLOT(quit()), Qt::DirectConnection);
+  loop.exec();
 }
 
 void ScriptFunctionsHelper::DialogSelectSlot(std::optional<QVector<int>>& resultOut, QWidget* parent, const QString& title, const QVector<QString>& items,

--- a/src/newstuff/rtfPopup.cpp
+++ b/src/newstuff/rtfPopup.cpp
@@ -8,7 +8,7 @@
 
 #include "../interop/QtDotNetConverters.h"
 
-RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QMainWindow(nullptr, f)
+RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QMainWindow(parent, f)
 {
   QString text = rtfText->StartsWith("{\\rtf") ? toQString(RtfPipe::Rtf::ToHtml(rtfText)) : Qt::convertFromPlainText(toQString(rtfText), Qt::WhiteSpaceNormal);
   QRegularExpression urlFinder(R"REGEX((?<!(?:href="))((?:(?:https?|ftp|file)://|www\.|ftp\.)(?:\([-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;)*\)|[-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;))*(?:\([-A-Z0-9+@#/%=~+|$?!:,.]|(?:&amp;)*\)|[A-Z0-9+@#/%=~_|$]|(?:&amp;))))REGEX", QRegularExpression::CaseInsensitiveOption | QRegularExpression::MultilineOption);

--- a/src/newstuff/rtfPopup.cpp
+++ b/src/newstuff/rtfPopup.cpp
@@ -8,18 +8,18 @@
 
 #include "../interop/QtDotNetConverters.h"
 
-RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QDialog(parent, f)
+RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) : QMainWindow(nullptr, f)
 {
   QString text = rtfText->StartsWith("{\\rtf") ? toQString(RtfPipe::Rtf::ToHtml(rtfText)) : Qt::convertFromPlainText(toQString(rtfText), Qt::WhiteSpaceNormal);
   QRegularExpression urlFinder(R"REGEX((?<!(?:href="))((?:(?:https?|ftp|file)://|www\.|ftp\.)(?:\([-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;)*\)|[-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;))*(?:\([-A-Z0-9+@#/%=~+|$?!:,.]|(?:&amp;)*\)|[A-Z0-9+@#/%=~_|$]|(?:&amp;))))REGEX", QRegularExpression::CaseInsensitiveOption | QRegularExpression::MultilineOption);
   text.replace(urlFinder, R"(<a href="\1">\1</a>)");
 
-  QLayout* layout = new QGridLayout(this);
-  setLayout(layout);
+  setAttribute(Qt::WA_DeleteOnClose);
+
   QScrollArea* scrollArea = new QScrollArea(this);
   scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  layout->addWidget(scrollArea);
+  setCentralWidget(scrollArea);
 
   QLabel* label = new QLabel(text, scrollArea);
   label->setWordWrap(true);
@@ -28,6 +28,10 @@ RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) 
   label->setTextInteractionFlags(Qt::TextBrowserInteraction);
   scrollArea->setWidget(label);
   scrollArea->setWidgetResizable(true);
+}
 
-  setSizeGripEnabled(true);
+void RtfPopup::closeEvent(QCloseEvent* event) 
+{
+  emit closed();
+  event->accept();
 }

--- a/src/newstuff/rtfPopup.cpp
+++ b/src/newstuff/rtfPopup.cpp
@@ -14,8 +14,6 @@ RtfPopup::RtfPopup(System::String^ rtfText, QWidget* parent, Qt::WindowFlags f) 
   QRegularExpression urlFinder(R"REGEX((?<!(?:href="))((?:(?:https?|ftp|file)://|www\.|ftp\.)(?:\([-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;)*\)|[-A-Z0-9+@#/%=~_|$?!:,.]|(?:&amp;))*(?:\([-A-Z0-9+@#/%=~+|$?!:,.]|(?:&amp;)*\)|[A-Z0-9+@#/%=~_|$]|(?:&amp;))))REGEX", QRegularExpression::CaseInsensitiveOption | QRegularExpression::MultilineOption);
   text.replace(urlFinder, R"(<a href="\1">\1</a>)");
 
-  setAttribute(Qt::WA_DeleteOnClose);
-
   QScrollArea* scrollArea = new QScrollArea(this);
   scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);

--- a/src/newstuff/rtfPopup.h
+++ b/src/newstuff/rtfPopup.h
@@ -1,11 +1,18 @@
 using namespace cli;
 
-#include <QDialog>
+#include <QMainWindow>
+#include <QCloseEvent>
 
-class RtfPopup : public QDialog
+class RtfPopup : public QMainWindow
 {
   Q_OBJECT
 
 public:
   RtfPopup(System::String^ rtfText, QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+
+signals:
+  void closed();
+
+protected:
+  void closeEvent(QCloseEvent* event);
 };

--- a/src/newstuff/rtfPopup.h
+++ b/src/newstuff/rtfPopup.h
@@ -14,5 +14,5 @@ signals:
   void closed();
 
 protected:
-  void closeEvent(QCloseEvent* event);
+  void closeEvent(QCloseEvent* event) override;
 };


### PR DESCRIPTION
Based on `frednet`, tested:

- Darnified UI - The README dialog is separate from the rest, which is pretty nice.
- `new_omod_2` with `DisplayText` - The popup is modal as expected (had to add a `QEventLoop`).
- The other popups (yes/no, etc.), seem to be above the README, which is not very nice... I think that it is possible to avoid this by changing the parent of one or the other and switching to `WindowModal`.